### PR TITLE
Download submodules also on repo sync

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote name="lirios" alias="origin" fetch="."/>
 
-  <default revision="develop" remote="lirios" sync-j="4"/>
+  <default revision="develop" remote="lirios" sync-j="8" sync-s="true"/>
 
   <project name="repotools" path="misc/repotools" groups="misc"/>
   <project name="lirios" path="misc/manifest" groups="misc">


### PR DESCRIPTION
Previously, it was required to sync submodules using `repo forall -c 'git submodule update --init --recursive'`

repo does this for us now. because of the increased repo count, I'm also setting the amoutn of concurrent downloads to 8.